### PR TITLE
fix bug due to Button.Tapped("MenuOk") including space

### DIFF
--- a/ArchipelagoRandomizer/UI/ConnectionMenu.cs
+++ b/ArchipelagoRandomizer/UI/ConnectionMenu.cs
@@ -173,8 +173,9 @@ internal class ConnectionMenu : CustomUI
 				yield return null;
 			}
 
-			if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk"))
+			if (!Input.GetKey(KeyCode.Space) & (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter) || Buttons.Tapped("MenuOk")))
 			{
+				//Filter out space so that folks can have spaces in Player names
 				ClickedConnect(null);
 			}
 			else if (Input.GetKeyDown(KeyCode.Tab) || Buttons.Tapped("MenuRight"))


### PR DESCRIPTION
Excludes space from triggering ClickedConnect because player names may contain spaces